### PR TITLE
LUT-30639 : Add security token validation for comment removal

### DIFF
--- a/src/java/fr/paris/lutece/plugins/extend/modules/comment/web/CommentApp.java
+++ b/src/java/fr/paris/lutece/plugins/extend/modules/comment/web/CommentApp.java
@@ -81,6 +81,7 @@ import fr.paris.lutece.portal.service.plugin.PluginService;
 import fr.paris.lutece.portal.service.prefs.UserPreferencesService;
 import fr.paris.lutece.portal.service.security.LuteceUser;
 import fr.paris.lutece.portal.service.security.SecurityService;
+import fr.paris.lutece.portal.service.security.SecurityTokenService;
 import fr.paris.lutece.portal.service.security.UserNotSignedException;
 import fr.paris.lutece.portal.service.spring.SpringContextService;
 import fr.paris.lutece.portal.service.template.AppTemplateService;
@@ -194,6 +195,8 @@ public class CommentApp implements XPageApplication
                         requestParameters.put( CommentConstants.PARAMETER_ID_COMMENT, strIdComment );
                         requestParameters.put( CommentConstants.PARAMETER_CONFIRM_REMOVE_COMMENT, "1" );
                         requestParameters.put( CommentConstants.PARAMETER_FROM_URL, strFromUrl );
+                        requestParameters.put( SecurityTokenService.PARAMETER_TOKEN,
+                                SecurityTokenService.getInstance( ).getToken( request, getTokenKey( strIdComment ) ) );
                         SiteMessageService.setMessage( request, CommentConstants.MESSAGE_CONFIRM_REMOVE_COMMENT, SiteMessage.TYPE_CONFIRMATION, JSP_PORTAL,
                                 requestParameters );
                     }
@@ -684,6 +687,11 @@ public class CommentApp implements XPageApplication
         return sbError.toString( );
     }
 
+    private static String getTokenKey( String strIdComment )
+    {
+        return CommentConstants.ACTION_REMOVE_COMMENT + "_" + strIdComment;
+    }
+
     /**
      * Send comment notification.
      * 
@@ -816,6 +824,12 @@ public class CommentApp implements XPageApplication
     {
         String strConfirmRemoveComment = String.valueOf( request.getParameter( CommentConstants.PARAMETER_CONFIRM_REMOVE_COMMENT ) );
         String strIdComment = String.valueOf( request.getParameter( CommentConstants.PARAMETER_ID_COMMENT ) );
+
+        if ( !SecurityTokenService.getInstance( ).validate( request, getTokenKey( strIdComment ) ) )
+        {
+            SiteMessageService.setMessage( request, CommentConstants.MESSAGE_ERROR_CANNOT_DELETE, SiteMessage.TYPE_ERROR );
+        }
+
         int nIdComment = Integer.parseInt( strIdComment );
         Comment comment = getCommentService( ).findByPrimaryKey( nIdComment );
         LuteceUser user = null;


### PR DESCRIPTION
On créé un token sur l'action ACTION_CONFIRM_REMOVE_COMMENT

<img width="1981" height="114" alt="image" src="https://github.com/user-attachments/assets/d63ac97b-1679-42d8-947a-618c05c2b505" />

Dans la methode getRemoveCommentTokenAction on créé la clé du token sous la forme removeComment_123 (on peut mettre n'importe quoi j'ai utilisé ici une constante deja en place) puis la valeur associé a cette clé est créé et enregistré pour la session et mises dans les parametres de la page.

Quand l'action doRemoveComment est lancée, on va lire si on a un token valide, si il ne l'est pas on affiche une erreur. Sinon on laisse passer. 

<img width="1919" height="491" alt="image" src="https://github.com/user-attachments/assets/c9366b3f-283b-420c-a6da-885ba7dea544" />

Le token est lié a une session, donc si on essaye de passer par u html externe (comme dans l'exemple du ticket https://dev.lutece.paris.fr/bugtracker/issues/30639) , la valeur n'est pas connue donc la suppression sera refusée
