### PR TITLE
LUT-32919 : CSRF token and open redirect control on comment add/remove

### DIFF
--- a/src/java/fr/paris/lutece/plugins/extend/modules/comment/web/CommentApp.java
+++ b/src/java/fr/paris/lutece/plugins/extend/modules/comment/web/CommentApp.java
@@ -196,7 +196,7 @@ public class CommentApp implements XPageApplication
                         requestParameters.put( CommentConstants.PARAMETER_CONFIRM_REMOVE_COMMENT, "1" );
                         requestParameters.put( CommentConstants.PARAMETER_FROM_URL, strFromUrl );
                         requestParameters.put( SecurityTokenService.PARAMETER_TOKEN,
-                                SecurityTokenService.getInstance( ).getToken( request, getTokenKey( strIdComment ) ) );
+                                SecurityTokenService.getInstance( ).getToken( request, getTokenKey( strIdExtendableResource, strExtendableResourceType ) ) );
                         SiteMessageService.setMessage( request, CommentConstants.MESSAGE_CONFIRM_REMOVE_COMMENT, SiteMessage.TYPE_CONFIRMATION, JSP_PORTAL,
                                 requestParameters );
                     }
@@ -430,6 +430,10 @@ public class CommentApp implements XPageApplication
             model.put( CommentConstants.MARK_WEBAPP_URL, AppPathService.getBaseUrl( request ) );
             model.put( CommentConstants.MARK_LOCALE, Locale.getDefault( ) );
 
+            // CSRF token to protect the doAddComment action (one token per extendable resource)
+            model.put( SecurityTokenService.MARK_TOKEN,
+                    SecurityTokenService.getInstance( ).getToken( request, getAddCommentTokenKey( strIdExtendableResource, strExtendableResourceType ) ) );
+
             // Add Captcha
             model.put( MARK_IS_ACTIVE_CAPTCHA, _bIsCaptchaEnabled );
 
@@ -476,6 +480,11 @@ public class CommentApp implements XPageApplication
     private XPage doAddComment( HttpServletRequest request, String strIdExtendableResource, String strExtendableResourceType )
             throws SiteMessageException, UserNotSignedException
     {
+        // CSRF protection : reject forged requests (missing or invalid security token)
+        if ( !SecurityTokenService.getInstance( ).validate( request, getAddCommentTokenKey( strIdExtendableResource, strExtendableResourceType ) ) )
+        {
+            SiteMessageService.setMessage( request, CommentConstants.MESSAGE_ERROR_GENERIC_MESSAGE, SiteMessage.TYPE_STOP );
+        }
 
         Comment comment = new Comment( );
         LuteceUser user = null;
@@ -653,11 +662,21 @@ public class CommentApp implements XPageApplication
         url.setAnchor( CommentConstants.ADD_COMMENT_MESSAGE_RESULT_ANCHOR );
         try
         {
-            response.sendRedirect( url.getUrl( ) );
+            String strRedirectUrl = url.getUrl( );
+            // Open redirect control : only redirect to internal (safe) URLs
+            if ( SecurityUtil.isInternalRedirectUrlSafe( strRedirectUrl, request ) )
+            {
+                response.sendRedirect( strRedirectUrl );
+            }
+            else
+            {
+                AppLogService.error( "module-extend-comment : open redirect blocked to {}", strRedirectUrl );
+                response.sendRedirect( AppPathService.getBaseUrl( request ) );
+            }
         }
         catch( IOException e )
         {
-            // log ?
+            AppLogService.error( e.getMessage( ), e );
         }
         return new XPage( );
     }
@@ -687,9 +706,24 @@ public class CommentApp implements XPageApplication
         return sbError.toString( );
     }
 
-    private static String getTokenKey( String strIdComment )
+    private static String getTokenKey( String strIdExtendableResource, String strExtendableResourceType )
     {
-        return CommentConstants.ACTION_REMOVE_COMMENT + "_" + strIdComment;
+        return CommentConstants.ACTION_REMOVE_COMMENT + "_" + strIdExtendableResource + "_" + strExtendableResourceType;
+    }
+
+    /**
+     * Builds the CSRF token key for the add comment action, scoped to a couple
+     * ( idExtendableResource, extendableResourceType ).
+     *
+     * @param strIdExtendableResource
+     *            the extendable resource id
+     * @param strExtendableResourceType
+     *            the extendable resource type
+     * @return the token key
+     */
+    public static String getAddCommentTokenKey( String strIdExtendableResource, String strExtendableResourceType )
+    {
+        return CommentConstants.ACTION_DO_ADD_COMMENT + "_" + strIdExtendableResource + "_" + strExtendableResourceType;
     }
 
     /**
@@ -825,7 +859,7 @@ public class CommentApp implements XPageApplication
         String strConfirmRemoveComment = String.valueOf( request.getParameter( CommentConstants.PARAMETER_CONFIRM_REMOVE_COMMENT ) );
         String strIdComment = String.valueOf( request.getParameter( CommentConstants.PARAMETER_ID_COMMENT ) );
 
-        if ( !SecurityTokenService.getInstance( ).validate( request, getTokenKey( strIdComment ) ) )
+        if ( !SecurityTokenService.getInstance( ).validate( request, getTokenKey( strIdExtendableResource, strExtendableResourceType ) ) )
         {
             SiteMessageService.setMessage( request, CommentConstants.MESSAGE_ERROR_CANNOT_DELETE, SiteMessage.TYPE_ERROR );
         }
@@ -888,11 +922,20 @@ public class CommentApp implements XPageApplication
                 HttpServletResponse response = LocalVariables.getResponse( );
                 try
                 {
-                    response.sendRedirect( strFromUrl );
+                    // Open redirect control : only redirect to internal (safe) URLs
+                    if ( SecurityUtil.isInternalRedirectUrlSafe( strFromUrl, request ) )
+                    {
+                        response.sendRedirect( strFromUrl );
+                    }
+                    else
+                    {
+                        AppLogService.error( "module-extend-comment : open redirect blocked to {}", strFromUrl );
+                        response.sendRedirect( AppPathService.getBaseUrl( request ) );
+                    }
                 }
                 catch( IOException e )
                 {
-                    // log ?
+                    AppLogService.error( e.getMessage( ), e );
                 }
                 return new XPage( );
             }

--- a/src/java/fr/paris/lutece/plugins/extend/modules/comment/web/component/CommentResourceExtenderComponent.java
+++ b/src/java/fr/paris/lutece/plugins/extend/modules/comment/web/component/CommentResourceExtenderComponent.java
@@ -57,6 +57,7 @@ import fr.paris.lutece.plugins.extend.modules.comment.service.CommentPlugin;
 import fr.paris.lutece.plugins.extend.modules.comment.service.ICommentService;
 import fr.paris.lutece.plugins.extend.modules.comment.service.extender.CommentResourceExtender;
 import fr.paris.lutece.plugins.extend.modules.comment.util.constants.CommentConstants;
+import fr.paris.lutece.plugins.extend.modules.comment.web.CommentApp;
 import fr.paris.lutece.plugins.extend.service.ExtendPlugin;
 import fr.paris.lutece.plugins.extend.service.content.ExtendableContentPostProcessor;
 import fr.paris.lutece.plugins.extend.service.extender.IResourceExtenderService;
@@ -75,6 +76,7 @@ import fr.paris.lutece.portal.service.prefs.UserPreferencesService;
 import fr.paris.lutece.portal.service.resource.IExtendableResource;
 import fr.paris.lutece.portal.service.security.LuteceUser;
 import fr.paris.lutece.portal.service.security.SecurityService;
+import fr.paris.lutece.portal.service.security.SecurityTokenService;
 import fr.paris.lutece.portal.service.spring.SpringContextService;
 import fr.paris.lutece.portal.service.template.AppTemplateService;
 import fr.paris.lutece.portal.service.util.AppPathService;
@@ -221,6 +223,10 @@ public class CommentResourceExtenderComponent extends AbstractResourceExtenderCo
             request.getSession( ).setAttribute( ExtendPlugin.PLUGIN_NAME + CommentConstants.PARAMETER_FROM_URL,
                     request.getRequestURI( ) + "?" + request.getQueryString( ) );
             model.put( CommentConstants.PARAMETER_FROM_URL, CommentConstants.FROM_SESSION );
+
+            // CSRF token to protect the doAddComment action (one token per extendable resource)
+            model.put( SecurityTokenService.MARK_TOKEN, SecurityTokenService.getInstance( )
+                    .getToken( request, CommentApp.getAddCommentTokenKey( strIdExtendableResource, strExtendableResourceType ) ) );
         }
 
         LuteceUser user = SecurityService.getInstance( ).getRegisteredUser( request );

--- a/webapp/WEB-INF/templates/skin/plugins/extend/modules/comment/add_comment.html
+++ b/webapp/WEB-INF/templates/skin/plugins/extend/modules/comment/add_comment.html
@@ -84,6 +84,7 @@
 					<div class="col-xs-12 col-sm-12 col-md-offset-3 col-lg-offset-3">
 						<input type="hidden" name="page" value="extend-comment" />
 						<input type="hidden" name="action" value="doAddComment" />
+						<input type="hidden" name="token" value="${token!}" />
 						<#if idComment??>
 							<input type="hidden" name="idParentComment" value="${idComment}" />
 						</#if>

--- a/webapp/WEB-INF/templates/skin/plugins/extend/modules/comment/comment.html
+++ b/webapp/WEB-INF/templates/skin/plugins/extend/modules/comment/comment.html
@@ -107,6 +107,7 @@
       <form class="form" method="post" action="jsp/site/Portal.jsp">
         <input type="hidden" name="page" value="extend-comment">
         <input type="hidden" name="action" value="doAddComment">
+        <input type="hidden" name="token" value="${token!}">
         <input type="hidden" name="idParentComment" value="${comment.idComment!}">
        
         <#if returnToCommentList?? && returnToCommentList>


### PR DESCRIPTION
Fixes the Open Redirect via CSRF reported on the extend-comment module.

- CSRF: add a security token (SecurityTokenService) to the doAddComment action, scoped per ( idExtendableResource, extendableResourceType ); the removeComment token is aligned on the same couple.
- Open redirect: both redirections (redirectToLastUrl, doRemoveComment) now validate the target with SecurityUtil.isInternalRedirectUrlSafe, falling back to the site base URL for external URLs.

Redmine: https://dev.lutece.paris.fr/bugtracker/issues/32919